### PR TITLE
fix to show human date display

### DIFF
--- a/.vitepress/theme/posts.data.mts
+++ b/.vitepress/theme/posts.data.mts
@@ -13,7 +13,13 @@ export default createContentLoader('blog/**/*.md', {
       .map(page => ({
         title: page.frontmatter.title,
         url: page.url,
-        date: page.frontmatter.date,
+        date: page.frontmatter.date
+          ? new Date(page.frontmatter.date).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })
+          : '',
         description: page.frontmatter.description,
         excerpt: page.excerpt,
         tags: page.frontmatter.tags


### PR DESCRIPTION
This pull request updates the way blog post dates are displayed by formatting them into a more readable string. Instead of showing the raw date, dates will now appear in a "Month Day, Year" format (e.g., "June 5, 2024"). If a post has no date, it will display an empty string.

Formatting improvements:

* Blog post dates in the blog data loader (`.vitepress/theme/posts.data.mts`) are now formatted using `toLocaleDateString` for better readability, falling back to an empty string if no date is present.